### PR TITLE
Fix get_palette method for big pucture

### DIFF
--- a/colorthief.py
+++ b/colorthief.py
@@ -62,7 +62,7 @@ class ColorThief(object):
         """
         image = self.image.convert('RGBA')
         width, height = image.size
-        pixels = list(image.getdata())
+        pixels = image.getdata()
         pixel_count = width * height
         valid_pixels = []
         for i in range(0, pixel_count, quality):


### PR DESCRIPTION
`list(image.getdata())` can crash of large images when small memory