### PR TITLE
Pass PIL Image Objects to ColorThief and Ignore White/Black Pixels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ API
                          must implement `read()`, `seek()`, and `tell()` methods,
                          and be opened in binary mode.
             :param is_obj: A boolean. If True, the object will be passed along. Useful
-                        for passing PIL objects to ColorThief.
+                         for passing PIL objects to ColorThief.
             """
             pass
 
@@ -47,6 +47,8 @@ API
                             the number, the faster a color will be returned but
                             the greater the likelihood that it will not be the
                             visually most dominant color
+            :param ignore_white: boolean, ignore white pixels if true
+            :param ignore_black: boolean, ignore black pixels if true
             :return tuple: (r, g, b)
             """
             pass
@@ -59,6 +61,8 @@ API
             :param quality: quality settings, 1 is the highest quality, the bigger
                             the number, the faster the palette generation, but the
                             greater the likelihood that colors will be missed.
+            :param ignore_white: boolean, ignore white pixels if true
+            :param ignore_black: boolean, ignore black pixels if true
             :return list: a list of tuple in the form (r, g, b)
             """
             pass

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ API
             :param file: A filename (string) or a file object. The file object
                          must implement `read()`, `seek()`, and `tell()` methods,
                          and be opened in binary mode.
+            :param is_obj: A boolean. If True, the object will be passed along. Useful
+                        for passing PIL objects to ColorThief.
             """
             pass
 

--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,10 @@ API
 .. code:: python
 
     class ColorThief(object):
-        def __init__(self, file):
+        def __init__(self, obj, is_obj=False):
             """Create one color thief for one image.
 
-            :param file: A filename (string) or a file object. The file object
+            :param obj: A filename (string) or a file object. The file object
                          must implement `read()`, `seek()`, and `tell()` methods,
                          and be opened in binary mode.
             :param is_obj: A boolean. If True, the object will be passed along. Useful

--- a/colorthief.py
+++ b/colorthief.py
@@ -42,19 +42,21 @@ class ColorThief(object):
         else:
             self.image = Image.open(obj)
 
-    def get_color(self, quality=10):
+    def get_color(self, ignore_white=False, ignore_black=False, quality=100000):
         """Get the dominant color.
 
         :param quality: quality settings, 1 is the highest quality, the bigger
                         the number, the faster a color will be returned but
                         the greater the likelihood that it will not be the
                         visually most dominant color
+        :param ignore_white: boolean, ignore white pixels if true
+        :param ignore_black: boolean, ignore black pixels if true
         :return tuple: (r, g, b)
         """
-        palette = self.get_palette(5, quality)
+        palette = self.get_palette(ignore_white, ignore_black, 5, quality)
         return palette[0]
 
-    def get_palette(self, color_count=10, quality=10):
+    def get_palette(self, ignore_white, ignore_black, color_count=10, quality=10):
         """Build a color palette.  We are using the median cut algorithm to
         cluster similar colors.
 
@@ -62,6 +64,8 @@ class ColorThief(object):
         :param quality: quality settings, 1 is the highest quality, the bigger
                         the number, the faster the palette generation, but the
                         greater the likelihood that colors will be missed.
+        :param ignore_white: boolean, ignore white pixels if true
+        :param ignore_black: boolean, ignore black pixels if true
         :return list: a list of tuple in the form (r, g, b)
         """
         image = self.image.convert('RGBA')
@@ -71,10 +75,21 @@ class ColorThief(object):
         valid_pixels = []
         for i in range(0, pixel_count, quality):
             r, g, b, a = pixels[i]
-            # If pixel is mostly opaque and not white
+            # If pixel is mostly opaque
             if a >= 125:
-                if not (r > 250 and g > 250 and b > 250):
+                if ignore_white or ignore_black is True:
+                    if ignore_white and ignore_black is True:
+                        if (r and g and b < 250) and (r and g and b > 5):
+                            valid_pixels.append((r, g, b))
+                        elif ignore_white is True and ignore_black is False:
+                            if (r and g and b < 250):
+                                valid_pixels.append((r, g, b))
+                        elif ignore_white is False and ignore_black is True:
+                            if (r and g and b > 5):
+                                valid_pixels.append((r, g, b))
+                else:
                     valid_pixels.append((r, g, b))
+
 
         # Send array to quantize function which clusters values
         # using median cut algorithm

--- a/colorthief.py
+++ b/colorthief.py
@@ -29,14 +29,18 @@ class cached_property(object):
 
 class ColorThief(object):
     """Color thief main class."""
-    def __init__(self, file):
+    def __init__(self, obj, is_obj=False):
         """Create one color thief for one image.
-
-        :param file: A filename (string) or a file object. The file object
+        :param obj: A filename (string) or a file object. The file object
                      must implement `read()`, `seek()`, and `tell()` methods,
                      and be opened in binary mode.
+        :param is_obj: A boolean. If True, the object will be passed along. Useful
+                        for passing PIL objects to ColorThief.
         """
-        self.image = Image.open(file)
+        if is_obj is True:
+            self.image = obj
+        else:
+            self.image = Image.open(obj)
 
     def get_color(self, quality=10):
         """Get the dominant color.


### PR DESCRIPTION
Thanks for your work on Color Thief! It's a really excellent tool.

I'm working on a Linux project to sync the dominant color of my primary display to my Hue Lights. Unfortunately, Hue Sync only works on Windows/Mac.

I'd rather not be I/O bound having to read/write to a disc to get the dominant color and would like to use your tool as a dependency. This pull request reflects the necessary changes to make that happen.

Here is a code snippet using the modified ColorThief class:
```python
#!/usr/bin/env python3

import pyscreenshot as ImageGrab
from displays import Monitor # Local import
from PIL import Image
from colorthief import ColorThief

# Get screen information from primary display
monitor = Monitor()
# Use pyscreenshot to grab a Linux screenshot using a native library
screen_grab = ImageGrab.grab(bbox=(monitor.x, monitor.y, monitor.width, monitor.height))
# Convert the image to a compatible PIL Image object
img = Image.frombytes('RGB', screen_grab.size, screen_grab.tobytes())
# Feed the PIL Image object to ColorThief
color_thief = ColorThief(img, True)
dominant_color = color_thief.get_color(quality=10000)
print(dominant_color)
```

